### PR TITLE
Update broken links to compatibility list

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,7 +305,7 @@ document.addEventListener('webkitfullscreenchange', function() {
 		<h2>Game Boy Advance in the Browser</h2>
 		<ul id="links">
 			<li><a href="http://github.com/jpfau/gbajs/">Fork me on GitHub!</a></li>
-			<li><a href="http://endrift.com/gbajs/compat.html">Compatibility list</a></li>
+			<li><a href="https://github.com/jpfau/gbajs/wiki/Compatibility-List">Compatibility list</a></li>
 		</ul>
 		<div id="stats">
 			<footer>Version 1.0 Beta 1</footer>
@@ -362,7 +362,7 @@ document.addEventListener('webkitfullscreenchange', function() {
 			Fairly decent! Most games run and are playable, although some will still crash at times
 			or lock up at specific points. Moreover, other minor bugs in graphics or sound are
 			still present, and I'm working on fixing those bugs. A compatibility list can be found
-			<a href="http://endrift.com/gbajs/compat.html">here</a>. Please report any bugs you
+			<a href="https://github.com/jpfau/gbajs/wiki/Compatibility-List">here</a>. Please report any bugs you
 			find on the <a href="http://github.com/jpfau/gbajs/issues">GitHub issue tracker</a>.
 			If you're feeling daring, you can also run the
 			<a href="console.html">debug version</a>, and post any useful information it spits out


### PR DESCRIPTION
The links to compatibility list in `index.html` are boken now.
This commit updates it to the correct one.
